### PR TITLE
Fix bug in two-site case (wrong boundary check)

### DIFF
--- a/src/tdvp.jl
+++ b/src/tdvp.jl
@@ -66,6 +66,7 @@ function tdvp(PH,
     )
   end
 
+
   @debug_check begin
     # Debug level checks
     # Enable with ITensors.enable_debug_checks()
@@ -101,6 +102,7 @@ function tdvp(PH,
   position!(PH, psi, 1)
 
   for sw in 1:nsweep(sweeps)
+    sw_time = @elapsed begin
     maxtruncerr = 0.0
 
     if !isnothing(write_when_maxdim_exceeds) &&
@@ -124,9 +126,10 @@ function tdvp(PH,
       end
 
       phi1, info = exponentiate(PH, t/2, phi1; 
-                               tol=exponentiate_tol,
-                               krylovdim=exponentiate_krylovdim,
-                               maxiter=exponentiate_maxiter)
+                                tol=exponentiate_tol,
+                                krylovdim=exponentiate_krylovdim,
+                                maxiter=exponentiate_maxiter)
+
 
       do_normalize && (phi1 /= norm(phi1))
 
@@ -161,7 +164,7 @@ function tdvp(PH,
       #
       # Do backwards evolution step
       #
-      if (ha==1 && b!=N) || (ha==2 && b!=1)
+      if (ha==1 && (b+nsite-1 != N)) || (ha==2 && b!=1)
         b1 = (ha == 1 ? b+1 : b)
         Δ = (ha==1 ? +1 : -1)
         if nsite == 2
@@ -216,6 +219,8 @@ function tdvp(PH,
         outputlevel=outputlevel,
         sweep_is_done=sweep_is_done,
       )
+
+    end
 
     end
 

--- a/test/tdvp.jl
+++ b/test/tdvp.jl
@@ -103,8 +103,8 @@ end
     end
 
 
-    push!(Sz_tdvp, expect(psi, "Sz"; site_range=c:c))
-    push!(Sz_exact, scalar(dag(prime(psix,s[c]))*Szc*psix))
+    push!(Sz_tdvp, real(expect(psi, "Sz"; site_range=c:c)))
+    push!(Sz_exact, real(scalar(dag(prime(psix,s[c]))*Szc*psix)))
     #F = abs(scalar(dag(psix)*prod(psi)))
     #@printf("%s=%.10f  exact=%.10f  F=%.10f\n",method,Sz_tdvp[end],Sz_exact[end],F)
   end

--- a/test/tdvp.jl
+++ b/test/tdvp.jl
@@ -1,3 +1,4 @@
+using Test
 using ITensors
 using ITensorTDVP
 using Printf
@@ -37,6 +38,77 @@ using Printf
 
   # Should rotate back to original state:
   @test abs(inner(ψ0,ψ2)) > 0.99
+end
+
+@testset "Accuracy Test" begin
+
+  N = 4
+  tau = 0.1
+  ttotal = 1.0
+  cutoff = 1E-12
+  use_trotter = false
+
+  s = siteinds("S=1/2", N; conserve_qns=false)
+
+  os = OpSum()
+  for j in 1:(N - 1)
+    os += 0.5, "S+", j, "S-", j + 1
+    os += 0.5, "S-", j, "S+", j + 1
+    os += "Sz", j, "Sz", j + 1
+  end
+  H = MPO(os, s)
+  HM = prod(H)
+
+  if use_trotter
+    gates = ITensor[]
+    for j in 1:(N - 1)
+      s1 = s[j]
+      s2 = s[j + 1]
+      hj =
+        op("Sz", s1) * op("Sz", s2) +
+        1 / 2 * op("S+", s1) * op("S-", s2) +
+        1 / 2 * op("S-", s1) * op("S+", s2)
+      Gj = exp(-1.0im * tau / 2 * hj)
+      push!(gates, Gj)
+    end
+    append!(gates, reverse(gates))
+  end
+
+  Ut = exp(-im*tau*HM)
+
+  psi = productMPS(s, n -> isodd(n) ? "Up" : "Dn")
+  psix = prod(psi)
+
+  Sz_tdvp = Float64[]
+  Sz_exact = Float64[]
+
+  c = div(N,2)
+  Szc = op("Sz",s[c])
+  Nsteps = Int(ttotal / tau)
+  for step in 1:Nsteps
+    if use_trotter
+      psi = apply(gates,psi; cutoff)
+      normalize!(psi)
+    else
+      psi = tdvp(H,psi,-tau*im; cutoff, 
+                                normalize=true,
+                                exponentiate_tol=1E-12,
+                                exponentiate_maxiter=500,
+                                exponentiate_krylovdim=100)
+    end
+
+    psix = noprime(Ut*psix)
+    psix /= norm(psix)
+
+    push!(Sz_tdvp, expect(psi, "Sz"; site_range=c:c))
+    push!(Sz_exact, scalar(dag(prime(psix,s[c]))*Szc*psix))
+    F = abs(scalar(dag(psix)*prod(psi)))
+    @printf("tdvp=%.10f  exact=%.10f  F=%.10f\n",Sz_tdvp[end],Sz_exact[end],F)
+  end
+
+  #@show norm(Sz_tdvp-Sz_exact)
+  @test norm(Sz_tdvp-Sz_exact) < 1E-3
+
 end
 
 
@@ -126,8 +198,11 @@ end
   Nsteps = Int(ttotal / tau)
   for step in 1:Nsteps
     nsite = (step <= 10 ? 2 : 1)
-    psi = tdvp(H,psi,-tau; cutoff, nsite, exponentiate_krylovdim=15)
-    @printf("%.3f energy = %.12f\n",step*tau,inner(psi,H,psi))
+    psi = tdvp(H,psi,-tau; cutoff, 
+                           nsite, 
+                           normalize=true,
+                           exponentiate_krylovdim=15)
+    #@printf("%.3f energy = %.12f\n",step*tau,inner(psi,H,psi))
   end
   @show maxlinkdim(psi)
 


### PR DESCRIPTION
Unfortunately I'm finding poor results in some cases. I added a new test which shows this, by comparing to an exact calculation for N=4 sites. When I use TEBD the results compare favorably to the exact ones, but using the current TDVP code I could not find a combination of settings which got anywhere near the same accuracy.

Checklist of some things I've tried / information about this:
- The accuracy issue is only in the 2-site case. When doing TEBD for one step followed by 1-site TDVP only, the accuracy is excellent and better than just TEBD.
- The issue doesn't seem to be the number of sweeps. I tried doing more sweeps and inputting the time step divided by the number of sweeps for the 2-site case, but it made no difference whatsoever (I did confirm that the additional sweeps were being done).

For my own convenience, I'm posting the link to the KrylovKit docs here: https://jutho.github.io/KrylovKit.jl/stable/man/matfun/
