### PR TITLE
Make TDVP generic to the solver

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,0 +1,2 @@
+style = "blue"
+indent = 2

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -1,0 +1,35 @@
+name: Format check
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  format:
+    name: "Format Check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: 1
+      - name: Install JuliaFormatter and format
+        run: |
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name="JuliaFormatter"))'
+          julia  -e 'using JuliaFormatter; format(".", verbose=true)'
+      - name: Check format
+        run: |
+          julia -e '
+          out = Cmd(`git diff --name-only`) |> read |> String
+          if out == ""
+              exit(0)
+          else
+              @error "The following files have not been formatted:"
+              write(stdout, out)
+              out_diff = Cmd(`git diff`) |> read |> String
+              @error "Diff:"
+              write(stdout, out_diff)
+              exit(1)
+              @error ""
+          end'

--- a/.github/workflows/format_pr.yml
+++ b/.github/workflows/format_pr.yml
@@ -1,0 +1,29 @@
+name: format-pr
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install JuliaFormatter and format
+        run: |
+          julia  -e 'import Pkg; Pkg.add("JuliaFormatter")'
+          julia  -e 'using JuliaFormatter; format(".")'
+      # https://github.com/marketplace/actions/create-pull-request
+      # https://github.com/peter-evans/create-pull-request#reference-example
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Format .jl files
+          title: 'Automatic JuliaFormatter.jl run'
+          branch: auto-juliaformatter-pr
+          delete-branch: true
+          labels: formatting, automated pr, no changelog
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/format_suggestions.yml
+++ b/.github/workflows/format_suggestions.yml
@@ -1,0 +1,27 @@
+name: Format suggestions
+
+on:
+  pull_request:
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: 1
+      - run: |
+          julia  -e 'using Pkg; Pkg.add("JuliaFormatter")'
+          julia  -e 'using JuliaFormatter; format("."; verbose=true)'
+      - uses: reviewdog/action-suggester@v1
+        with:
+          tool_name: JuliaFormatter
+          fail_on_error: true
+          filter_mode: added

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,21 +4,16 @@ using Documenter
 DocMeta.setdocmeta!(ITensorTDVP, :DocTestSetup, :(using ITensorTDVP); recursive=true)
 
 makedocs(;
-    modules=[ITensorTDVP],
-    authors="Matthew Fishman <mfishman@flatironinstitute.org> and contributors",
-    repo="https://github.com/mtfishman/ITensorTDVP.jl/blob/{commit}{path}#{line}",
-    sitename="ITensorTDVP.jl",
-    format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://mtfishman.github.io/ITensorTDVP.jl",
-        assets=String[],
-    ),
-    pages=[
-        "Home" => "index.md",
-    ],
+  modules=[ITensorTDVP],
+  authors="Matthew Fishman <mfishman@flatironinstitute.org> and contributors",
+  repo="https://github.com/mtfishman/ITensorTDVP.jl/blob/{commit}{path}#{line}",
+  sitename="ITensorTDVP.jl",
+  format=Documenter.HTML(;
+    prettyurls=get(ENV, "CI", "false") == "true",
+    canonical="https://mtfishman.github.io/ITensorTDVP.jl",
+    assets=String[],
+  ),
+  pages=["Home" => "index.md"],
 )
 
-deploydocs(;
-    repo="github.com/mtfishman/ITensorTDVP.jl",
-    devbranch="main",
-)
+deploydocs(; repo="github.com/mtfishman/ITensorTDVP.jl", devbranch="main")

--- a/examples/tdvp.jl
+++ b/examples/tdvp.jl
@@ -19,7 +19,17 @@ H = MPO(heisenberg(n), s)
 
 @show inner(ψ', H, ψ) / inner(ψ, ψ)
 
-ϕ = tdvp(H, ψ, -1; nsweeps=10, reverse_step=false, normalize=true, maxdim=20, cutoff=1e-10, outputlevel=1)
+ϕ = tdvp(
+  H,
+  ψ,
+  -1;
+  nsweeps=10,
+  reverse_step=false,
+  normalize=true,
+  maxdim=20,
+  cutoff=1e-10,
+  outputlevel=1,
+)
 
 @show inner(ϕ', H, ϕ) / inner(ϕ, ϕ)
 

--- a/examples/tdvp.jl
+++ b/examples/tdvp.jl
@@ -17,10 +17,16 @@ end
 H = MPO(heisenberg(n), s)
 ψ = randomMPS(s, "↑"; linkdims=10)
 
-@show inner(ψ', H, ψ)
+@show inner(ψ', H, ψ) / inner(ψ, ψ)
 
-_, ϕ = tdvp(H, ψ; t=-0.1*im, exponentiate_krylovdim=30, nsweeps=10, maxdim=50, cutoff=1e-10)
+ϕ = tdvp(H, ψ, -1; nsweeps=10, reverse_step=false, normalize=true, maxdim=20, cutoff=1e-10, outputlevel=1)
+
+@show inner(ϕ', H, ϕ) / inner(ϕ, ϕ)
 
 e2, ϕ2 = dmrg(H, ψ; nsweeps=10, maxdim=20, cutoff=1e-10)
 
-@show inner(ϕ', H, ϕ)
+@show inner(ϕ2', H, ϕ2) / inner(ϕ2, ϕ2)
+
+ϕ3 = ITensorTDVP.dmrg(H, ψ; nsweeps=10, maxdim=20, cutoff=1e-10, outputlevel=1)
+
+@show inner(ϕ3', H, ϕ3) / inner(ϕ3, ϕ3)

--- a/src/ITensorTDVP.jl
+++ b/src/ITensorTDVP.jl
@@ -1,7 +1,7 @@
 module ITensorTDVP
 
 using ITensors
-using KrylovKit: exponentiate
+using KrylovKit: exponentiate, eigsolve
 using Printf
 
 using ITensors: AbstractMPS, @debug_check, @timeit_debug, check_hascommoninds, orthocenter

--- a/src/tdvp.jl
+++ b/src/tdvp.jl
@@ -1,60 +1,5 @@
-
-"""
-    tdvp(H::MPO,psi0::MPS,t::Number,sweeps::Sweeps; kwargs...)
-
-Use the time dependent variational principle (TDVP) algorithm
-to compute `exp(t*H)*psi0` using an efficient algorithm based
-on alternating optimization of the MPS tensors and local Krylov
-exponentiation of H.
-                    
-Returns:
-* `psi::MPS` - time-evolved MPS
-
-Optional keyword arguments:
-* `outputlevel::Int = 1` - larger outputlevel values resulting in printing more information and 0 means no output
-* `observer` - object implementing the [Observer](@ref observer) interface which can perform measurements and stop early
-* `write_when_maxdim_exceeds::Int` - when the allowed maxdim exceeds this value, begin saving tensors to disk to free memory in large calculations
-"""
-function tdvp(H::MPO, psi0::MPS, t::Number, sweeps::Sweeps; kwargs...)::MPS
-  check_hascommoninds(siteinds, H, psi0)
-  check_hascommoninds(siteinds, H, psi0')
-  # Permute the indices to have a better memory layout
-  # and minimize permutations
-  H = ITensors.permute(H, (linkind, siteinds, linkind))
-  PH = ProjMPO(H)
-  return tdvp(PH, psi0, t, sweeps; kwargs...)
-end
-
-"""
-    tdvp(Hs::Vector{MPO},psi0::MPS,t::Number,sweeps::Sweeps;kwargs...)
-
-Use the time dependent variational principle (TDVP) algorithm
-to compute `exp(t*H)*psi0` using an efficient algorithm based
-on alternating optimization of the MPS tensors and local Krylov
-exponentiation of H.
-                    
-This version of `tdvp` accepts a representation of H as a
-Vector of MPOs, Hs = [H1,H2,H3,...] such that H is defined
-as H = H1+H2+H3+...
-Note that this sum of MPOs is not actually computed; rather
-the set of MPOs [H1,H2,H3,..] is efficiently looped over at 
-each step of the algorithm when optimizing the MPS.
-
-Returns:
-* `psi::MPS` - time-evolved MPS
-"""
-function tdvp(Hs::Vector{MPO}, psi0::MPS, t::Number, sweeps::Sweeps; kwargs...)::MPS
-  for H in Hs
-    check_hascommoninds(siteinds, H, psi0)
-    check_hascommoninds(siteinds, H, psi0')
-  end
-  Hs .= ITensors.permute.(Hs, Ref((linkind, siteinds, linkind)))
-  PHS = ProjMPOSum(Hs)
-  return tdvp(PHS, psi0, t, sweeps; kwargs...)
-end
-
-
-function tdvp(PH,
+function tdvp(solver,
+              PH,
               psi0::MPS,
               t::Number,
               sweeps;
@@ -75,6 +20,7 @@ function tdvp(PH,
   end
 
   nsite::Int = get(kwargs, :nsite, 2)
+  reverse_step::Bool = get(kwargs, :reverse_step, true)
   normalize::Bool = get(kwargs, :normalize, false)
   outputlevel::Int = get(kwargs, :outputlevel, 0)
   which_decomp::Union{String,Nothing} = get(kwargs, :which_decomp, nothing)
@@ -84,14 +30,6 @@ function tdvp(PH,
   write_when_maxdim_exceeds::Union{Int,Nothing} = get(
     kwargs, :write_when_maxdim_exceeds, nothing
   )
-
-  # exponentiate keyword args
-  tol = get(kwargs, :exponentiate_tol, 1E-12)
-  exponentiate_kw = (;ishermitian= get(kwargs, :exponentiate_ishermitian, true),
-                      tol = get(kwargs, :exponentiate_tol, tol),
-                      krylovdim= get(kwargs, :exponentiate_krylovdim, 30),
-                      maxiter= get(kwargs, :exponentiate_maxiter, 100),
-                      verbosity= get(kwargs, :exponentiate_verbosity, 0))
 
   psi = copy(psi0)
   N = length(psi)
@@ -127,12 +65,12 @@ function tdvp(PH,
         phi1 = psi[b]*psi[b+1]
       end
 
-      phi1, info = exponentiate(PH, t/2, phi1; exponentiate_kw...)
+      phi1, info = solver(PH, t/2, phi1)
 
-      if info.converged == 0
-        println("exponentiate not converged (b,ha)=($b,$ha)")
-        ITensors.pause()
-      end
+      ## if info.converged == 0
+      ##   println("exponentiate not converged (b,ha)=($b,$ha)")
+      ##   ITensors.pause()
+      ## end
 
       normalize && (phi1 /= norm(phi1))
 
@@ -167,7 +105,7 @@ function tdvp(PH,
       #
       # Do backwards evolution step
       #
-      if (ha==1 && (b+nsite-1 != N)) || (ha==2 && b!=1)
+      if reverse_step && (ha==1 && (b+nsite-1 != N)) || (ha==2 && b!=1)
         b1 = (ha == 1 ? b+1 : b)
         Δ = (ha==1 ? +1 : -1)
         if nsite == 2
@@ -182,7 +120,7 @@ function tdvp(PH,
         PH.nsite = nsite-1
         position!(PH,psi,b1)
 
-        phi0,info = exponentiate(PH, -t/2, phi0; exponentiate_kw...)
+        phi0, info = solver(PH, -t/2, phi0)
 
         normalize && (phi0 ./= norm(phi0))
 
@@ -247,7 +185,6 @@ function tdvp(PH,
   return psi
 end
 
-
 function _tdvp_sweeps(; nsweeps=1, maxdim=typemax(Int), mindim=1, cutoff=1E-8, noise=0.0, kwargs...)
   sweeps = Sweeps(nsweeps)
   setmaxdim!(sweeps, maxdim...)
@@ -257,10 +194,94 @@ function _tdvp_sweeps(; nsweeps=1, maxdim=typemax(Int), mindim=1, cutoff=1E-8, n
   return sweeps
 end
 
-function tdvp(x1, x2, psi0::MPS, t::Number; kwargs...)
-  return tdvp(x1, x2, psi0, t, _tdvp_sweeps(; kwargs...); kwargs...)
+function tdvp(solver, x1, x2, psi0::MPS, t::Number; kwargs...)
+  return tdvp(solver, x1, x2, psi0, t, _tdvp_sweeps(; kwargs...); kwargs...)
 end
 
-function tdvp(x1, psi0::MPS, t::Number; kwargs...)
-  return tdvp(x1, psi0, t, _tdvp_sweeps(; kwargs...); kwargs...)
+function tdvp(solver, x1, psi0::MPS, t::Number; kwargs...)
+  return tdvp(solver, x1, psi0, t, _tdvp_sweeps(; kwargs...); kwargs...)
+end
+
+"""
+    tdvp(H::MPO,psi0::MPS,t::Number,sweeps::Sweeps; kwargs...)
+
+Use the time dependent variational principle (TDVP) algorithm
+to compute `exp(t*H)*psi0` using an efficient algorithm based
+on alternating optimization of the MPS tensors and local Krylov
+exponentiation of H.
+                    
+Returns:
+* `psi::MPS` - time-evolved MPS
+
+Optional keyword arguments:
+* `outputlevel::Int = 1` - larger outputlevel values resulting in printing more information and 0 means no output
+* `observer` - object implementing the [Observer](@ref observer) interface which can perform measurements and stop early
+* `write_when_maxdim_exceeds::Int` - when the allowed maxdim exceeds this value, begin saving tensors to disk to free memory in large calculations
+"""
+function tdvp(solver, H::MPO, psi0::MPS, t::Number, sweeps::Sweeps; kwargs...)::MPS
+  check_hascommoninds(siteinds, H, psi0)
+  check_hascommoninds(siteinds, H, psi0')
+  # Permute the indices to have a better memory layout
+  # and minimize permutations
+  H = ITensors.permute(H, (linkind, siteinds, linkind))
+  PH = ProjMPO(H)
+  return tdvp(solver, PH, psi0, t, sweeps; kwargs...)
+end
+
+"""
+    tdvp(Hs::Vector{MPO},psi0::MPS,t::Number,sweeps::Sweeps;kwargs...)
+
+Use the time dependent variational principle (TDVP) algorithm
+to compute `exp(t*H)*psi0` using an efficient algorithm based
+on alternating optimization of the MPS tensors and local Krylov
+exponentiation of H.
+                    
+This version of `tdvp` accepts a representation of H as a
+Vector of MPOs, Hs = [H1,H2,H3,...] such that H is defined
+as H = H1+H2+H3+...
+Note that this sum of MPOs is not actually computed; rather
+the set of MPOs [H1,H2,H3,..] is efficiently looped over at 
+each step of the algorithm when optimizing the MPS.
+
+Returns:
+* `psi::MPS` - time-evolved MPS
+"""
+function tdvp(solver, Hs::Vector{MPO}, psi0::MPS, t::Number, sweeps::Sweeps; kwargs...)::MPS
+  for H in Hs
+    check_hascommoninds(siteinds, H, psi0)
+    check_hascommoninds(siteinds, H, psi0')
+  end
+  Hs .= ITensors.permute.(Hs, Ref((linkind, siteinds, linkind)))
+  PHS = ProjMPOSum(Hs)
+  return tdvp(solver, PHS, psi0, t, sweeps; kwargs...)
+end
+
+function tdvp(PH, psi0::MPS, t::Number; reverse_step=true, kwargs...)
+  solver_kwargs = (; ishermitian=get(kwargs, :ishermitian, true),
+                     tol=get(kwargs, :exponentiate_tol, 1e-12),
+                     krylovdim=get(kwargs, :exponentiate_krylovdim, 30),
+                     maxiter=get(kwargs, :exponentiate_maxiter, 100),
+                     verbosity=get(kwargs, :exponentiate_verbosity, 0))
+  function solver(PH, t, psi0)
+    psi, info = exponentiate(PH, t, psi0; solver_kwargs...)
+    return psi, info
+  end
+  return tdvp(solver, PH, psi0, t; reverse_step, kwargs...)
+end
+
+function dmrg(PH, psi0::MPS; reverse_step=false, kwargs...)
+  t = Inf # DMRG is TDVP with an infinite timestep and no reverse step
+  howmany = 1
+  which = get(kwargs, :eigsolve_which_eigenvalue, :SR)
+  solver_kwargs = (; ishermitian=get(kwargs, :ishermitian, true),
+                     tol=get(kwargs, :eigsolve_tol, 1e-14),
+                     krylovdim=get(kwargs, :eigsolve_krylovdim, 3),
+                     maxiter=get(kwargs, :eigsolve_maxiter, 1),
+                     verbosity=get(kwargs, :eigsolve_verbosity, 0))
+  function solver(PH, t, psi0)
+    vals, vecs, info = eigsolve(PH, psi0, howmany, which; solver_kwargs...)
+    psi = vecs[1]
+    return psi, info
+  end
+  return tdvp(solver, PH, psi0, t; reverse_step, kwargs...)
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"
+KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/tdvp.jl
+++ b/test/tdvp.jl
@@ -1,12 +1,12 @@
 using Test
 using ITensors
 using ITensorTDVP
+using KrylovKit
 using Printf
-
 
 @testset "Basic TDVP" begin
   N = 10
-  cutoff = 1E-10
+  cutoff = 1e-10
 
   s = siteinds("S=1/2", N)
 
@@ -29,7 +29,7 @@ using Printf
   #@test abs(inner(ψ0,ψ1)) < 0.9
 
   # Average energy should be conserved:
-  @test real(inner(ψ1,H,ψ1)) ≈ inner(ψ0,H,ψ0)
+  @test real(inner(ψ1, H, ψ1)) ≈ inner(ψ0, H, ψ0)
 
   # Time evolve backwards:
   ψ2 = tdvp(H, ψ1, +0.1im; cutoff)
@@ -37,12 +37,12 @@ using Printf
   @test norm(ψ2) ≈ 1.0
 
   # Should rotate back to original state:
-  @test abs(inner(ψ0,ψ2)) > 0.99
+  @test abs(inner(ψ0, ψ2)) > 0.99
 end
 
 @testset "Custom solver in TDVP" begin
   N = 10
-  cutoff = 1E-10
+  cutoff = 1e-10
 
   s = siteinds("S=1/2", N)
 
@@ -58,11 +58,7 @@ end
   ψ0 = randomMPS(s; linkdims=10)
 
   function solver(PH, t, psi0)
-    solver_kwargs = (; ishermitian=true,
-                     tol=1e-12,
-                     krylovdim=30,
-                     maxiter=100,
-                     verbosity=0)
+    solver_kwargs = (; ishermitian=true, tol=1e-12, krylovdim=30, maxiter=100, verbosity=0)
     psi, info = exponentiate(PH, t, psi0; solver_kwargs...)
     return psi, info
   end
@@ -75,7 +71,7 @@ end
   #@test abs(inner(ψ0,ψ1)) < 0.9
 
   # Average energy should be conserved:
-  @test real(inner(ψ1,H,ψ1)) ≈ inner(ψ0,H,ψ0)
+  @test real(inner(ψ1, H, ψ1)) ≈ inner(ψ0, H, ψ0)
 
   # Time evolve backwards:
   ψ2 = tdvp(H, ψ1, +0.1im; cutoff)
@@ -83,15 +79,14 @@ end
   @test norm(ψ2) ≈ 1.0
 
   # Should rotate back to original state:
-  @test abs(inner(ψ0,ψ2)) > 0.99
+  @test abs(inner(ψ0, ψ2)) > 0.99
 end
 
 @testset "Accuracy Test" begin
-
   N = 4
   tau = 0.02
   ttotal = 1.0
-  cutoff = 1E-12
+  cutoff = 1e-12
   use_trotter = false
 
   method = use_trotter ? "tebd" : "tdvp"
@@ -122,7 +117,7 @@ end
     append!(gates, reverse(gates))
   end
 
-  Ut = exp(-im*tau*HM)
+  Ut = exp(-im * tau * HM)
 
   psi = productMPS(s, n -> isodd(n) ? "Up" : "Dn")
   psix = prod(psi)
@@ -130,40 +125,42 @@ end
   Sz_tdvp = Float64[]
   Sz_exact = Float64[]
 
-  c = div(N,2)
-  Szc = op("Sz",s[c])
+  c = div(N, 2)
+  Szc = op("Sz", s[c])
   Nsteps = Int(ttotal / tau)
   for step in 1:Nsteps
-    psix = noprime(Ut*psix)
+    psix = noprime(Ut * psix)
     psix /= norm(psix)
 
     if use_trotter
-      psi = apply(gates,psi; cutoff)
+      psi = apply(gates, psi; cutoff)
       normalize!(psi)
     else
-      psi = tdvp(H,psi,-tau*im; cutoff, 
-                                normalize=true,
-                                exponentiate_tol=1E-12,
-                                exponentiate_maxiter=500,
-                                exponentiate_krylovdim=100)
+      psi = tdvp(
+        H,
+        psi,
+        -tau * im;
+        cutoff,
+        normalize=true,
+        exponentiate_tol=1e-12,
+        exponentiate_maxiter=500,
+        exponentiate_krylovdim=100,
+      )
     end
 
-
     push!(Sz_tdvp, real(expect(psi, "Sz"; site_range=c:c)))
-    push!(Sz_exact, real(scalar(dag(prime(psix,s[c]))*Szc*psix)))
+    push!(Sz_exact, real(scalar(dag(prime(psix, s[c])) * Szc * psix)))
     #F = abs(scalar(dag(psix)*prod(psi)))
     #@printf("%s=%.10f  exact=%.10f  F=%.10f\n",method,Sz_tdvp[end],Sz_exact[end],F)
   end
 
   #@show norm(Sz_tdvp-Sz_exact)
-  @test norm(Sz_tdvp-Sz_exact) < 1E-5
-
+  @test norm(Sz_tdvp - Sz_exact) < 1e-5
 end
-
 
 @testset "TEBD Comparison" begin
   N = 10
-  cutoff = 1E-12
+  cutoff = 1e-12
   tau = 0.1
   ttotal = 1.0
 
@@ -207,15 +204,12 @@ end
     normalize!(psi)
 
     nsite = (step <= 3 ? 2 : 1)
-    phi = tdvp(H,phi,-tau*im; cutoff, 
-                              nsite, 
-                              normalize=true,
-                              exponentiate_krylovdim=15)
+    phi = tdvp(H, phi, -tau * im; cutoff, nsite, normalize=true, exponentiate_krylovdim=15)
 
     Sz1[step] = expect(psi, "Sz"; site_range=c:c)
     Sz2[step] = expect(phi, "Sz"; site_range=c:c)
-    En1[step] = real(inner(psi,H,psi))
-    En2[step] = real(inner(phi,H,phi))
+    En1[step] = real(inner(psi, H, psi))
+    En2[step] = real(inner(phi, H, phi))
   end
 
   #display(En1)
@@ -223,14 +217,13 @@ end
   #display(Sz1)
   #display(Sz2)
 
-  @test norm(Sz1-Sz2) < 1E-3
-  @test norm(En1-En2) < 1E-3
-
+  @test norm(Sz1 - Sz2) < 1e-3
+  @test norm(En1 - En2) < 1e-3
 end
 
 @testset "Imaginary Time Evolution" begin
   N = 10
-  cutoff = 1E-12
+  cutoff = 1e-12
   tau = 1.0
   ttotal = 50.0
 
@@ -245,21 +238,45 @@ end
 
   H = MPO(os, s)
 
-  psi = randomMPS(s;linkdims=2)
+  psi = randomMPS(s; linkdims=2)
 
   Nsteps = Int(ttotal / tau)
   for step in 1:Nsteps
     nsite = (step <= 10 ? 2 : 1)
-    psi = tdvp(H,psi,-tau; cutoff, 
-                           nsite, 
-                           normalize=true,
-                           exponentiate_krylovdim=15)
-    @printf("%.3f energy = %.12f\n",step*tau,inner(psi,H,psi))
+    psi = tdvp(H, psi, -tau; cutoff, nsite, normalize=true, exponentiate_krylovdim=15)
+    @printf("%.3f energy = %.12f\n", step * tau, inner(psi, H, psi))
   end
   #@show maxlinkdim(psi)
 
-  @test inner(psi,H,psi) < -4.25
+  @test inner(psi, H, psi) < -4.25
+end
 
+@testset "DMRG" begin
+  N = 10
+  cutoff = 1e-12
+
+  s = siteinds("S=1/2", N)
+
+  os = OpSum()
+  for j in 1:(N - 1)
+    os += 0.5, "S+", j, "S-", j + 1
+    os += 0.5, "S-", j, "S+", j + 1
+    os += "Sz", j, "Sz", j + 1
+  end
+
+  H = MPO(os, s)
+
+  psi = randomMPS(s; linkdims=2)
+
+  Nsteps = 10
+  nsite = 2
+  psi = ITensorTDVP.dmrg(
+    H, psi; nsweeps=Nsteps, cutoff, nsite, eigsolve_krylovdim=3, eigsolve_maxiter=1
+  )
+
+  e2, psi2 = dmrg(H, psi; nsweeps=Nsteps, cutoff, normalize=true)
+
+  @test inner(psi, H, psi) ≈ inner(psi2, H, psi2)
 end
 
 nothing

--- a/test/tdvp.jl
+++ b/test/tdvp.jl
@@ -274,7 +274,7 @@ end
     H, psi; nsweeps=Nsteps, cutoff, nsite, eigsolve_krylovdim=3, eigsolve_maxiter=1
   )
 
-  e2, psi2 = dmrg(H, psi; nsweeps=Nsteps, cutoff, normalize=true)
+  e2, psi2 = dmrg(H, psi; nsweeps=Nsteps, maxdim=100, cutoff, normalize=true)
 
   @test inner(psi, H, psi) ≈ inner(psi2, H, psi2)
 end


### PR DESCRIPTION
Make TDVP generic to the solver, so that a custom solver can be passed.

The standard `tdvp` uses `KrylovKit.exponentiate`, and I've implemented a `ITensorTDVP.dmrg` function that uses `KrylovKit.eigsolve`. A user can optionally pass any solver they want as the first input to `tdvp`, and turn off the reverse time step (which is useful for DMRG and imaginary time evolution TDVP).