### PR TITLE
Fix TDVP for sums of MPOs (or general `AbstactProjMPO`)

### DIFF
--- a/src/ITensorTDVP.jl
+++ b/src/ITensorTDVP.jl
@@ -6,6 +6,10 @@ using Printf
 
 using ITensors: AbstractMPS, @debug_check, @timeit_debug, check_hascommoninds, orthocenter
 
+# Overloads needed for ITensors.jl
+# To port to ITensors.jl
+include(joinpath("ITensors", "abstractprojmpo.jl"))
+
 include("tdvp.jl")
 
 export tdvp

--- a/src/ITensors/abstractprojmpo.jl
+++ b/src/ITensors/abstractprojmpo.jl
@@ -1,0 +1,33 @@
+using ITensors: AbstractProjMPO, ProjMPO, ProjMPOSum, ProjMPS, ProjMPO_MPS, DiskProjMPO
+
+set_nsite!(::AbstractProjMPO, nsite) = error("Not implemented")
+
+function set_nsite!(P::ProjMPO, nsite)
+  P.nsite = nsite
+  return P
+end
+
+function set_nsite!(Ps::ProjMPOSum, nsite)
+  for P in Ps.pm
+    set_nsite!(P, nsite)
+  end
+  return Ps
+end
+
+function set_nsite!(P::ProjMPS, nsite)
+  P.nsite = nsite
+  return P
+end
+
+function set_nsite!(Ps::ProjMPO_MPS, nsite)
+  set_nsite!(Ps.PH, nsite)
+  for P in Ps.pm
+    set_nsite!(P, nsite)
+  end
+  return Ps
+end
+
+function set_nsite!(P::DiskProjMPO, nsite)
+  P.nsite = nsite
+  return P
+end

--- a/src/tdvp.jl
+++ b/src/tdvp.jl
@@ -49,7 +49,7 @@ function tdvp(solver, PH, psi0::MPS, t::Number, sweeps; kwargs...)::MPS
       end
 
       for (b, ha) in sweepnext(N; ncenter=nsite)
-        PH.nsite = nsite
+        set_nsite!(PH, nsite)
         position!(PH, psi, b)
 
         if nsite == 1
@@ -109,7 +109,7 @@ function tdvp(solver, PH, psi0::MPS, t::Number, sweeps; kwargs...)::MPS
             phi0 = S * V
           end
 
-          PH.nsite = nsite - 1
+          set_nsite!(PH, nsite - 1)
           position!(PH, psi, b1)
 
           phi0, info = solver(PH, -t / 2, phi0)
@@ -121,7 +121,7 @@ function tdvp(solver, PH, psi0::MPS, t::Number, sweeps; kwargs...)::MPS
           elseif nsite == 1
             psi[b + Δ] = phi0 * psi[b + Δ]
           end
-          PH.nsite = nsite
+          set_nsite!(PH, nsite)
         end
 
         if outputlevel >= 2

--- a/test/tdvp.jl
+++ b/test/tdvp.jl
@@ -40,6 +40,49 @@ using Printf
   @test abs(inner(ψ0, ψ2)) > 0.99
 end
 
+@testset "TDVP: Sum of Hamiltonians" begin
+  N = 10
+  cutoff = 1e-10
+
+  s = siteinds("S=1/2", N)
+
+  os1 = OpSum()
+  for j in 1:(N - 1)
+    os1 += 0.5, "S+", j, "S-", j + 1
+    os1 += 0.5, "S-", j, "S+", j + 1
+  end
+  os2 = OpSum()
+  for j in 1:(N - 1)
+    os2 += 0.5, "S+", j, "S-", j + 1
+    os2 += 0.5, "S-", j, "S+", j + 1
+    os2 += "Sz", j, "Sz", j + 1
+  end
+
+  H1 = MPO(os1, s)
+  H2 = MPO(os2, s)
+  Hs = [H1, H2]
+
+  ψ0 = randomMPS(s; linkdims=10)
+
+  ψ1 = tdvp(Hs, ψ0, -0.1im; cutoff, nsite=1)
+
+  @test norm(ψ1) ≈ 1.0
+
+  ## Should lose fidelity:
+  #@test abs(inner(ψ0,ψ1)) < 0.9
+
+  # Average energy should be conserved:
+  @test real(sum(H -> inner(ψ1, H, ψ1), Hs)) ≈ sum(H -> inner(ψ0, H, ψ0), Hs)
+
+  # Time evolve backwards:
+  ψ2 = tdvp(Hs, ψ1, +0.1im; cutoff)
+
+  @test norm(ψ2) ≈ 1.0
+
+  # Should rotate back to original state:
+  @test abs(inner(ψ0, ψ2)) > 0.99
+end
+
 @testset "Custom solver in TDVP" begin
   N = 10
   cutoff = 1e-10


### PR DESCRIPTION
The only part that wasn't generic for general inputs were lines setting the number of center sites with `PH.nsite = nsite`.

This Introduces `set_nsite!`, a generic `AbstractProjMPO` function for setting the number of center sites. This will be moved to ITensors, just putting it here now so for expediency and so we can test it out.